### PR TITLE
Add tests for core_utils utilities

### DIFF
--- a/src/salespyforce/utils/tests/test_core_utils.py
+++ b/src/salespyforce/utils/tests/test_core_utils.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""
+:Module:         salespyforce.utils.tests.test_core_utils
+:Synopsis:       This module is used by pytest to test core utility functions
+:Created By:     Jeff Shurtliff
+:Last Modified:  Anonymous
+:Modified Date:  19 Dec 2025
+"""
+
+import os
+import pathlib
+import warnings
+
+import pytest
+
+from salespyforce import errors
+from salespyforce.utils import core_utils
+
+
+def test_url_encode_and_decode_round_trip():
+    """This function tests URL encoding and decoding helper functions."""
+    raw_string = "My sample string with spaces & symbols!"
+    encoded = core_utils.url_encode(raw_string)
+    assert "%26" in encoded and "+" in encoded
+    decoded = core_utils.url_decode(encoded)
+    assert decoded == raw_string
+
+
+def test_display_warning_emits_userwarning():
+    """This function tests that display_warning emits a UserWarning."""
+    warn_msg = "testing warning"
+    with pytest.warns(UserWarning, match=warn_msg):
+        core_utils.display_warning(warn_msg)
+
+
+def test_get_file_type_detects_json_extension(tmp_path):
+    """This function tests get_file_type with a JSON extension."""
+    json_path = tmp_path / "config.json"
+    json_path.write_text('{"key": "value"}')
+    assert core_utils.get_file_type(str(json_path)) == "json"
+
+
+def test_get_file_type_detects_yaml_extension(tmp_path):
+    """This function tests get_file_type with a YAML extension."""
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text("key: value")
+    assert core_utils.get_file_type(str(yaml_path)) == "yaml"
+
+
+def test_get_file_type_reads_unknown_extension_with_warning(tmp_path):
+    """This function tests get_file_type fallback detection on unknown extensions."""
+    txt_path = tmp_path / "config.txt"
+    txt_path.write_text("# comment line\n{json: true}")
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        file_type = core_utils.get_file_type(str(txt_path))
+    assert file_type == "json"
+    assert any(
+        warning.category is UserWarning for warning in captured_warnings
+    )
+
+
+def test_get_file_type_raises_for_unknown_content(tmp_path):
+    """This function tests get_file_type when content is unrecognized."""
+    bad_path = tmp_path / "config.data"
+    bad_path.write_text("plain text content")
+    with pytest.warns(UserWarning):
+        with pytest.raises(errors.exceptions.UnknownFileTypeError):
+            core_utils.get_file_type(str(bad_path))
+
+
+def test_get_file_type_raises_for_missing_file():
+    """This function tests get_file_type when a file is missing."""
+    missing_path = "does/not/exist.json"
+    with pytest.raises(FileNotFoundError):
+        core_utils.get_file_type(missing_path)
+
+
+def test_get_random_string_returns_expected_length(monkeypatch):
+    """This function tests get_random_string length and prefix handling."""
+    alphabet = "abc123"
+    monkeypatch.setattr(core_utils, "random", core_utils.random)
+    monkeypatch.setattr(
+        core_utils,
+        "string",
+        type("DummyString", (), {"ascii_letters": alphabet, "digits": alphabet}),
+    )
+    result = core_utils.get_random_string(length=5, prefix_string="pre_")
+    assert result.startswith("pre_")
+    assert len(result) == 5 + len("pre_")
+    assert all(char in alphabet for char in result.replace("pre_", ""))
+
+
+def test_get_image_ref_id_parses_query_param():
+    """This function tests get_image_ref_id parsing."""
+    image_url = (
+        "https://example.force.com/servlet/servlet.ImageServer"
+        "?oid=00Dxx0000001gPFEAY&refid=abc123&lastMod=123"
+    )
+    assert core_utils.get_image_ref_id(image_url) == "abc123"
+
+
+def test_download_image_raises_without_input():
+    """This function tests download_image when neither URL nor response is provided."""
+    with pytest.raises(RuntimeError):
+        core_utils.download_image()
+
+
+def test_download_image_raises_on_bad_status(monkeypatch, tmp_path):
+    """This function tests download_image when the response is unsuccessful."""
+    class DummyResponse:
+        status_code = 404
+        content = b""
+
+    monkeypatch.setattr(core_utils.requests, "get", lambda *_args, **_kwargs: DummyResponse())
+    with pytest.raises(RuntimeError):
+        core_utils.download_image(image_url="https://example.com/image", file_path=str(tmp_path))
+
+
+def test_download_image_writes_response_content(tmp_path):
+    """This function tests download_image writing provided response content."""
+    file_path = tmp_path / "images"
+    os.makedirs(file_path, exist_ok=True)
+
+    class DummyResponse:
+        status_code = 200
+        content = b"image-bytes"
+
+    destination = core_utils.download_image(
+        image_url="https://example.com/image",
+        file_name="logo.png",
+        file_path=str(file_path),
+        response=DummyResponse(),
+    )
+    saved_path = pathlib.Path(destination)
+    assert saved_path.name == "logo.png"
+    assert saved_path.parent == file_path
+    assert saved_path.read_bytes() == DummyResponse.content
+
+
+def test_download_image_generates_file_name(monkeypatch, tmp_path):
+    """This function tests download_image generates a file name when not provided."""
+    class DummyResponse:
+        status_code = 200
+        content = b"bytes"
+
+    monkeypatch.setattr(core_utils, "get_random_string", lambda *_args, **_kwargs: "image_stub")
+    destination = core_utils.download_image(
+        image_url="https://example.com/image",
+        file_path=str(tmp_path),
+        response=DummyResponse(),
+        extension="png",
+    )
+    assert destination.startswith(f"{tmp_path}{os.sep}image_stub")
+    assert destination.endswith("png")
+    assert pathlib.Path(destination).read_bytes() == DummyResponse.content


### PR DESCRIPTION
## Summary
- add pytest coverage for core utility helpers including URL encoding/decoding, warnings, and file type detection
- verify random string generation, image ref parsing, and download handling paths

## Testing
- poetry run pytest src/salespyforce/utils/tests/test_core_utils.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945e38071c48329b4964980b26007f1)