### PR TITLE
Add delete() helper to salespyforce.api

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,7 @@ Changes to the :doc:`supporting modules <supporting-modules>` are listed below.
 * Added the :py:mod:`salespyforce.utils.tests.conftest` module to configure pytest for unit testing.
 * Added the :py:mod:`salespyforce.utils.tests.test_core_utils` module to test the core utilities.
 * Added the :py:mod:`salespyforce.utils.tests.test_log_utils` module to test the logging functionality.
+* Added the :py:func:`salespyforce.api.delete` function to perform DELETE API requests.
 
 General
 -------

--- a/src/salespyforce/api.py
+++ b/src/salespyforce/api.py
@@ -3,8 +3,8 @@
 :Module:            salespyforce.api
 :Synopsis:          Defines the basic functions associated with the Salesforce API
 :Created By:        Jeff Shurtliff
-:Last Modified:     Jeff Shurtliff
-:Modified Date:     17 Feb 2023
+:Last Modified:     Anonymous
+:Modified Date:     29 Jan 2026
 """
 
 import requests
@@ -114,6 +114,48 @@ def api_call_with_payload(sfdc_object, method, endpoint, payload, params=None, h
             response = response.json()
         except Exception as exc:
             print(f'Failed to convert the API response to JSON format due to the following exception: {exc}')
+    return response
+
+
+def delete(sfdc_object, endpoint, params=None, headers=None, timeout=30, show_full_error=True, return_json=True):
+    """This method performs a DELETE request against the Salesforce instance.
+    (`Reference <https://jereze.com/code/authentification-salesforce-rest-api-python/>`_)
+
+    :param sfdc_object: The instantiated SalesPyForce object
+    :param endpoint: The API endpoint to query
+    :type endpoint: str
+    :param params: The query parameters (where applicable)
+    :type params: dict, None
+    :param headers: Specific API headers to use when performing the API call
+    :type headers: dict, None
+    :param timeout: The timeout period in seconds (defaults to ``30``)
+    :type timeout: int, str, None
+    :param show_full_error: Determines if the full error message should be displayed (defaults to ``True``)
+    :type show_full_error: bool
+    :param return_json: Determines if the response should be returned in JSON format (defaults to ``True``)
+    :returns: The API response in JSON format or as a ``requests`` object
+    """
+    # Define the parameters as an empty dictionary if none are provided
+    params = {} if params is None else params
+
+    # Define the headers
+    default_headers = _get_headers(sfdc_object.access_token)
+    headers = default_headers if not headers else headers
+
+    # Make sure the endpoint begins with a slash
+    endpoint = f'/{endpoint}' if not endpoint.startswith('/') else endpoint
+
+    # Perform the API call
+    response = requests.delete(f'{sfdc_object.instance_url}{endpoint}', headers=headers, params=params,
+                               timeout=timeout)
+    if response.status_code >= 300:
+        if show_full_error:
+            raise RuntimeError(f'The DELETE request failed with a {response.status_code} status code.\n'
+                               f'{response.text}')
+        else:
+            raise RuntimeError(f'The DELETE request failed with a {response.status_code} status code.')
+    if return_json:
+        response = response.json()
     return response
 
 


### PR DESCRIPTION
### Motivation

- Provide a simple, consistent helper to perform HTTP DELETE calls against Salesforce using the same patterns as existing `get()` and `api_call_with_payload()` helpers.
- Keep the module metadata up-to-date to reflect the change.

### Description

- Added `delete(sfdc_object, endpoint, params=None, headers=None, timeout=30, show_full_error=True, return_json=True)` to `src/salespyforce/api.py` directly above `_get_headers()` and implemented it using `requests.delete()` with the same header handling and error semantics used by other helpers.
- The new function normalizes `params`, ensures the `endpoint` begins with `/`, uses `_get_headers()` for default authentication headers, raises `RuntimeError` for HTTP status codes >= 300 (optionally including the full error text), and optionally returns parsed JSON when `return_json` is `True`.
- Updated the module header (`Last Modified` and `Modified Date`) in `src/salespyforce/api.py` to `Anonymous` and `29 Jan 2026` (MST) and documented the new function in `docs/changelog.rst`.

### Testing

- No automated tests were executed as part of this change (no `pytest` run was requested or performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bbb2964cc8329847395e13ba2bee0)