### PR TITLE
Add Salesforce.delete core method

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ Additions to the :doc:`core-object-methods` are listed below.
 * Added the :py:meth:`salespyforce.core.Salesforce.get_latest_api_version` method which retrieves
   the latest API version by querying the authorized Salesforce org, returning the version as a
   string (e.g. ``65.0``)
+* Added the :py:meth:`salespyforce.core.Salesforce.delete` method to perform DELETE requests
+  against the authorized Salesforce instance
 * Added the ``FALLBACK_SFDC_API_VERSION`` constant that is leveraged if the
   :py:meth:`salespyforce.core.Salesforce.get_latest_api_version` method fails to retrieve the
   latest API version for the authorized Salesforce org

--- a/src/salespyforce/core.py
+++ b/src/salespyforce/core.py
@@ -5,8 +5,8 @@
 :Usage:             ``from salespyforce import Salesforce``
 :Example:           ``sfdc = Salesforce(helper=helper_file_path)``
 :Created By:        Jeff Shurtliff
-:Last Modified:     Jeff Shurtliff
-:Modified Date:     17 Nov 2025
+:Last Modified:     Anonymous (via GPT-5.2-Codex)
+:Modified Date:     29 Jan 2026
 """
 
 import re
@@ -274,6 +274,26 @@ class Salesforce(object):
         return api.api_call_with_payload(self, 'put', endpoint=endpoint, payload=payload, params=params,
                                          headers=headers, timeout=timeout, show_full_error=show_full_error,
                                          return_json=return_json)
+
+    def delete(self, endpoint, params=None, headers=None, timeout=30, show_full_error=True, return_json=True):
+        """This method performs a DELETE request against the Salesforce instance.
+        (`Reference <https://jereze.com/code/authentification-salesforce-rest-api-python/>`_)
+
+        :param endpoint: The API endpoint to query
+        :type endpoint: str
+        :param params: The query parameters (where applicable)
+        :type params: dict, None
+        :param headers: Specific API headers to use when performing the API call
+        :type headers: dict, None
+        :param timeout: The timeout period in seconds (defaults to ``30``)
+        :type timeout: int, str, None
+        :param show_full_error: Determines if the full error message should be displayed (defaults to ``True``)
+        :type show_full_error: bool
+        :param return_json: Determines if the response should be returned in JSON format (defaults to ``True``)
+        :returns: The API response in JSON format or as a ``requests`` object
+        """
+        return api.delete(self, endpoint=endpoint, params=params, headers=headers, timeout=timeout,
+                          show_full_error=show_full_error, return_json=return_json)
 
     def get_api_versions(self) -> list:
         """This method returns the API versions for the Salesforce releases.


### PR DESCRIPTION
### Motivation

- Provide a `Salesforce.delete()` convenience method on the core client that mirrors the existing `get()`/`put()` behavior and delegates DELETE operations to the `salespyforce.api.delete` helper.
- Keep the public API consistent and documented so callers can perform DELETE requests via the high-level `Salesforce` object.
- Update module metadata to reflect the change per project doc requirements.

### Description

- Added `def delete(self, endpoint, params=None, headers=None, timeout=30, show_full_error=True, return_json=True)` to the `Salesforce` class directly below the existing `put()` method in `src/salespyforce/core.py` and implemented it to call `api.delete(self, ...)`.
- Wrote a Sphinx-style docstring for `Salesforce.delete()` following the same structure and naming as the existing `get()` method.
- Updated the file header in `src/salespyforce/core.py` to set `Last Modified` to `Anonymous (via GPT-5.2-Codex)` and `Modified Date` to `29 Jan 2026` (MST) as required by project docs.
- Updated `docs/changelog.rst` under `v1.4.0.dev2 > Added > Core Object` to document the new `:py:meth:
  `salespyforce.core.Salesforce.delete` method.

### Testing

- No automated tests were run for this change.
- Changes were limited to adding a small delegating method and documentation updates, so no new test artifacts were included.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bf3c0d86483298422b8c92f543ccc)