### PR TITLE
[TEST] Cover pyproject.toml fallback and add tests for get_version_from_pyproject

### DIFF
--- a/src/salespyforce/utils/tests/test_version_utils.py
+++ b/src/salespyforce/utils/tests/test_version_utils.py
@@ -4,8 +4,8 @@
 :Module:         salespyforce.utils.tests.test_version_utils
 :Synopsis:       Pytest suite for salespyforce.utils.version helpers
 :Created By:     Jeff Shurtliff
-:Last Modified:  Jeff Shurtliff
-:Modified Date:  20 Dec 2025
+:Last Modified:  Anonymous (via GPT-5.2-Codex)
+:Modified Date:  19 Feb 2026
 """
 
 import importlib
@@ -30,12 +30,12 @@ def test_get_full_version_handles_missing_package(monkeypatch, caplog):
         raise version_utils.PackageNotFoundError("salespyforce")
 
     monkeypatch.setattr(version_utils, "version", raise_not_found)
+    monkeypatch.setattr(version_utils, "get_version_from_pyproject", lambda: "5.4.3")
 
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG"):
         version_string = version_utils.get_full_version()
 
-    assert version_string == "0.0.0"
-    assert any("falling back to '0.0.0'" in message for message in caplog.messages)
+    assert version_string == "5.4.3"
 
 
 def test_get_major_minor_version_returns_two_components(monkeypatch):
@@ -54,9 +54,36 @@ def test_get_major_minor_version_returns_full_when_missing_minor(monkeypatch):
     assert version_utils.get_major_minor_version() == "7"
 
 
+def test_get_version_from_pyproject_reads_project_version(tmp_path):
+    """This function tests get_version_from_pyproject with PEP 621 layout."""
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text('[project]\nversion = "3.2.1"\n', encoding="utf-8")
+
+    assert version_utils.get_version_from_pyproject(str(pyproject_file)) == "3.2.1"
+
+
+def test_get_version_from_pyproject_reads_poetry_version(tmp_path):
+    """This function tests get_version_from_pyproject with Poetry layout."""
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text('[tool.poetry]\nversion = "4.5.6"\n', encoding="utf-8")
+
+    assert version_utils.get_version_from_pyproject(str(pyproject_file)) == "4.5.6"
+
+
+def test_get_version_from_pyproject_returns_default_when_missing_version(tmp_path, caplog):
+    """This function tests get_version_from_pyproject fallback default value."""
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text('[project]\nname = "salespyforce"\n', encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        version_string = version_utils.get_version_from_pyproject(str(pyproject_file))
+
+    assert version_string == "0.0.0"
+    assert any("falling back to '0.0.0'" in message for message in caplog.messages)
+
+
 def test_dunder_version_matches_full_version(monkeypatch):
     """This function tests __version__ initialization uses get_full_version."""
-    real_version_function = importlib_metadata.version
     expected_version = "9.8.7"
     monkeypatch.setattr(
         importlib_metadata, "version", lambda package: expected_version
@@ -65,6 +92,4 @@ def test_dunder_version_matches_full_version(monkeypatch):
     reloaded_module = importlib.reload(version_utils)
     assert reloaded_module.__version__ == expected_version
     assert reloaded_module.get_full_version() == expected_version
-
-    importlib_metadata.version = real_version_function
     importlib.reload(version_utils)


### PR DESCRIPTION
### Motivation

- Ensure `get_full_version()` fallback to `get_version_from_pyproject()` is correctly tested when package metadata is missing.
- Add unit tests to fully exercise the new `get_version_from_pyproject()` implementation for both PEP 621 and Poetry layouts.
- Keep tests deterministic and small while preserving existing public behavior for `get_major_minor_version()` and `__version__` initialization.

### Description

- Updated `test_get_full_version_handles_missing_package()` to monkeypatch `get_version_from_pyproject()` and assert that `get_full_version()` returns the pyproject-derived version when metadata is missing.
- Added three tests for `get_version_from_pyproject()` covering PEP 621 (`[project]`), Poetry (`[tool.poetry]`), and the default `0.0.0` fallback with a warning.
- Simplified the `__version__` reload test cleanup by relying on module reload/`monkeypatch` semantics and updated the file header `Last Modified` and `Modified Date` metadata.

### Testing

- Ran `poetry run pytest src/salespyforce/utils/tests/test_version_utils.py` and all tests passed (`8 passed`).
- Attempted coverage checks with pytest-cov and `coverage`, but the environment lacks those tools so coverage reporting could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69974a2b0eac83298c444efe90f71a3e)